### PR TITLE
polymer cheat sheet section added - `dom-repeat` item 2 way binding

### DIFF
--- a/_posts/2016-12-13-polymer-cheatsheet.markdown
+++ b/_posts/2016-12-13-polymer-cheatsheet.markdown
@@ -412,3 +412,18 @@ Docs: [dom-repeat](https://www.polymer-project.org/1.0/docs/api/dom-repeat),
   <span>This content will appear when myProperty is truthy.</span>
 </template>{% endraw %}  
 ```
+
+ `dom-repeat` item 2 way binding :
+ 
+```html
+{% raw %}<ul>
+  <template is="dom-repeat" items="[[forms]]">
+    <paper-checkbox label="Enable [[item.name]]" checked="{{item.fieldset_enabled}}"></paper-checkbox>
+    <template is="dom-if" if="[[item.fieldset_enabled]]">
+      <fieldset><legend> '[[item.name]]' section </legend>
+         ...
+      </fieldset>
+    </template>
+  </template>
+</ul>{% endraw %}  
+```


### PR DESCRIPTION
Definitely expandable details would be beneficial for more than trivial code sniplet like proposed. But that concept is not a part of cheat sheet. 

     <details>
        <summary>`dom-repeat` item 2 way binding :</summary>
        Two-way databinding in dom-repeat could be based on extending the item model with component-specific field ( where it is a good habit to use component-specific prefix).<br/>
        In sample the fieldset is shown only upon checkbox selection.
    </details>
Which looks like
<details>
        <summary><b>dom-repeat</b> item 2 way binding :</summary>
        Two-way databinding in dom-repeat could be based on extending the item model with component-specific field ( where it is a good habit to use component-specific prefix).<br/>
        In sample the fieldset is shown only upon checkbox selection.
</details>

The link to external discussion thread(disquse, reddit , etc.) related to section would be handy too. 